### PR TITLE
Check local var asm

### DIFF
--- a/DataLoader.cs
+++ b/DataLoader.cs
@@ -79,8 +79,7 @@ namespace ModShardLauncher
                     {
                         ShowWarning(warning, "Loading warning");
 
-                        if (warning.Contains("unserializeCountError.txt")
-                            || warning.Contains("object pool size"))
+                        if (warning.Contains("unserializeCountError.txt") || warning.Contains("object pool size"))
                             return;
 
                         hadWarnings = true;

--- a/FileReader.cs
+++ b/FileReader.cs
@@ -65,7 +65,7 @@ namespace ModShardLauncher
 
             // https://sonarsource.github.io/rspec/#/rspec/S6602/csharp
             // for list, Find should be used instead of FirstOrDefault
-            FileChunk? file = Files.Find(t => System.IO.Path.GetFileName(t.name) == fileName);
+            FileChunk? file = Files.Find(t => System.IO.Path.GetFileName(t.name) == System.IO.Path.GetFileName(fileName));
             if (file != null)
             {
                 if(!Stream.CanRead) Stream = new FileStream(Path, FileMode.Open);
@@ -82,7 +82,11 @@ namespace ModShardLauncher
             try
             {
                 byte[] data = GetFile(fileName);
-
+                if (data.Length == 0) 
+                {
+                    Log.Warning($"{fileName} is empty.");
+                    return "";
+                }
                 // if a BOM is found aka: 0xEF 0xBB 0xBF at the beginning of the file, remove it since UTMT will not understand these characters.
                 // BOM are produced if a script is made through Visual Studio
                 if (data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF) data = data.Skip(3).ToArray();

--- a/ModUtils/EventUtils.cs
+++ b/ModUtils/EventUtils.cs
@@ -165,6 +165,7 @@ namespace ModShardLauncher
         { 
             switch(eventType)
             {
+                case EventType.PreCreate:
                 case EventType.Create:
                 case EventType.Destroy:
                 case EventType.Trigger:


### PR DESCRIPTION
When patching with asm as string:
- Improve the global var checking: previously if an already local var was using the same name, then the global var would not be created, since it would be flagged as already existing. Currently, if such a var is injected, it will be correctly created
- Add a specific checker for local var
- Add a string builder for local var to inject them in the header of a asm file
- Change the log message to display more information