### PR TITLE
[Minor] Bump version to v0.12.0.0

### DIFF
--- a/ModShardLauncher.csproj
+++ b/ModShardLauncher.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>ico.ico</ApplicationIcon>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 	  <SatelliteResourceLanguages>zh-Hans</SatelliteResourceLanguages>
-    <FileVersion>0.11.4.0</FileVersion>
+    <FileVersion>0.12.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup> <!-- Include the specific files to exclude the ones in the test folder -->


### PR DESCRIPTION
What's new for everyone:

- Installing and merging mods is much, much faster.
- Small screens everywhere, rejoice! The MSL window can now shrink. Only if your screen is actually small, though, don't get any ideas.

What's new for modders:

- It now uses a different version of the UnderTaleModdingTool (UTMTCE) under the hood, which is better, faster, and wears sunglasses indoors. For an actual list of actual features, check out the repo here: https://github.com/XDOneDude/UndertaleModToolCE. This means that we now reccomend you use UTMTCE when viewing Stoneshard's code for modding.
- This also means that the code is decompiled in a slightly different way. Mainly: `true` and `false` are correctly decompiled instead of showing up as `1` and `0`; object names are often shown instead of their cryptic ID number. If you have any questions, feel free to join the Stoneshard Mod Hub discord server: https://discord.gg/VT3jeDwjR3
- You can now access and edit many important scripts that were extremely complicated to edit before. This makes modding certain parts of the game, such as right-click context menus, 10 times faster and more reliable. This stat is a made up number and yet 110% correct.
- Note that `.sml` files compiled by this version of the MSL can not be used by older versions of the MSL. However, the reverse is feasible. This means that you need to clarify the version compatibility of MSL in the Mod installation guide.